### PR TITLE
Update city progress on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,24 @@ Please read [these instructions] (https://github.com/opensmc/ssmc-agriculture-zo
 ## Cities completed
 
 * Atherton
-* Foster City
-* Portola Valley
-* San Bruno
-* San Carlos
-* San Mateo
-
-## Cities in progress
-
 * Belmont
 * Brisbane
 * Burlingame
 * Colma
-* Daly City
 * East Palo Alto
-* Half Moon Bay
+* Foster City
 * Hillsborough
 * Menlo Park
 * Millbrae
+* Portola Valley
+* San Bruno
+* San Carlos
+
+## Cities in progress
+
+* Daly City
+* Half Moon Bay
 * Pacifica
 * Redwood City
+* San Mateo
+* Woodside


### PR DESCRIPTION
I see files in the zoning boundaries directory for Redwood City and Woodside, but they aren't displaying correctly on Github. Is this because they are not in WGS84?

Also San Mateo was previously listed as completed, but I don't see a file for it.
